### PR TITLE
[DO NOT MERGE] Feature: #4, services as rpc api

### DIFF
--- a/config/services.config.php
+++ b/config/services.config.php
@@ -34,7 +34,7 @@ return array(
         },
 
         'kjsencha.modulefactory' => function(ServiceLocatorInterface $sl) {
-            return new ModuleFactory($sl->get('kjsencha.annotationmanager'));
+            return new ModuleFactory($sl->get('kjsencha.annotationmanager'), $sl);
         },
 
         'kjsencha.cache' => function(ServiceLocatorInterface $sl) {

--- a/src/KJSencha/Direct/Remoting/Api/Factory/AbstractFactory.php
+++ b/src/KJSencha/Direct/Remoting/Api/Factory/AbstractFactory.php
@@ -10,7 +10,7 @@ use KJSencha\Direct\Remoting\Api\Object\Action;
 use KJSencha\Direct\Remoting\Api\Object\Method;
 
 use Zend\Code\Scanner\DirectoryScanner;
-use Zend\Code\Scanner\DerivedClassScanner;
+use Zend\Code\Scanner\ClassScanner;
 use Zend\Code\Annotation\AnnotationManager;
 
 /**
@@ -31,7 +31,7 @@ abstract class AbstractFactory
      * @param  string $path Path to a valid directory
      * @return Api    The API object
      */
-    public function buildFromDirectory($path)
+    protected function buildFromDirectory($path)
     {
         if (!is_dir($path)) {
             throw new InvalidArgumentException('Invalid directory given: "' . $path . '"');
@@ -48,10 +48,10 @@ abstract class AbstractFactory
     }
 
     /**
-     * @param DerivedClassScanner $class
+     * @param ClassScanner $class
      * @return Action
      */
-    public function buildObjectFromClass(DerivedClassScanner $class)
+    protected function buildObjectFromClass(ClassScanner $class)
     {
         $action = new Action($class->getName());
 

--- a/view/kjsencha/bootstrap.phtml
+++ b/view/kjsencha/bootstrap.phtml
@@ -1,37 +1,38 @@
-<script type="text/javascript">
-<?php $this->headScript()->captureStart(); ?>
+<script type="text/javascript"><?php
+$this->headScript()->captureStart();
+echo PHP_EOL;
 
-    <?php if($bootstrap->getVariables()): ?>
-        <?php foreach ($bootstrap->getVariables() as $key => $value): ?>
-        var <?php echo $key; ?> = <?php echo json_encode($value) . ';' . PHP_EOL; ?>
-        <?php endforeach; ?>
-    <?php endif; ?>
+/* @var $bootstrap \KJSencha\Frontend\Bootstrap */
+if($bootstrap->getVariables()) {
+    foreach ($bootstrap->getVariables() as $key => $value) {
+        echo $key . '=' . json_encode($value) . ';' . PHP_EOL;
+    }
+}
 
-    <?php if ($namespaces = $bootstrap->getPaths()): ?>
-    <?php
+if ($namespaces = $bootstrap->getPaths()) {
     // Create relative paths for paths that have no trailing slash
     foreach ($namespaces as $namespace => $path) {
         if ($path[0] !== '/') {
             $namespaces[$namespace] = $this->basePath($path);
         }
     }
-    ?>
 
-    Ext.Loader.setConfig(<?php echo json_encode(array(
-        'enabled'  => TRUE,
+    echo 'Ext.Loader.setConfig(' . json_encode(array(
+        'enabled'  => true,
         'paths'    => $namespaces,
-    )); ?>);
-    <?php endif; ?>
+    )) . ');' . PHP_EOL;
+}
 
-    <?php if ($requires = $bootstrap->getRequires()): ?>
-    Ext.syncRequire(<?php echo json_encode($requires); ?>);
-    <?php endif; ?>
-        
-    <?php if ($directApi = $bootstrap->getDirectApi()): ?>
-        <?php foreach ($bootstrap->getModules() as $module => $options): ?>
-            <?php echo $directApi->getModule($module)->buildRemotingProvider($options); ?>
-        <?php endforeach; ?>
-    <?php endif; ?>
+if ($requires = $bootstrap->getRequires()) {
+    echo 'Ext.syncRequire(' . json_encode($requires) . ');' . PHP_EOL;
+}
 
-<?php $this->headScript()->captureEnd(); ?>
-</script>
+if ($directApi = $bootstrap->getDirectApi()) {
+    foreach ($bootstrap->getModules() as $module => $options) {
+        echo $directApi->getModule($module)->buildRemotingProvider($options);
+    }
+}
+
+echo PHP_EOL;
+$this->headScript()->captureEnd();
+?></script>


### PR DESCRIPTION
# Services as RPC services

This is a PoC for #4
## Usage
1.  Define your own service (`Your\Module#getServiceConfig()`):
   
   ``` php
    return array(
        'factories' => array(
            'my_cool_test_service' => function ($sm) {
               return new \My\Awesome\Service($sm->get('cool_stuff'));
            },
        ),
    );
   ```
2.  Ma your service in the `kjsencha` config (`Your\Module#getConfig()`):
    `php
    return array(
        'kjsencha' => array(
            'direct' => array(
                'modules' => array(
                    // to be removed?
                ),
                'services' => array(
                    // mapping FQCN (JS-side) to the services that provide the API
                    'My.test.service'           => 'my_cool_test_service',
                    'Grid'                      => 'my_cool_test_service',
                    'Application.direct.Grid'   => 'my_cool_test_service',
                ),
            ),
            'bootstrap' => array(
                'default' => array(
                    'modules' => array(
                        // hack to produce some actual output. output isn't yet valid though (TBD)
                        '' => array(
                            'namespace' => '',
                        ),
                    ),
                ),
            ),
        ),
    );
   ``
